### PR TITLE
Change dotnet icon to purple square

### DIFF
--- a/internal/versions/dotnet.go
+++ b/internal/versions/dotnet.go
@@ -5,7 +5,7 @@ import (
 )
 
 var Dotnet = section{
-	symbol: "\uE77F", // 
+	symbol: "🟪", // Purple square
 	color:  ansi.Magenta,
 
 	upsearchFiles: []string{


### PR DESCRIPTION
The previous icon (`\uE77F`) didn't work properly with common fonts, so change it to 🟪.